### PR TITLE
Switch to map

### DIFF
--- a/packages/await-io/src/npm-package.ts
+++ b/packages/await-io/src/npm-package.ts
@@ -34,17 +34,20 @@ export class NpmPackage extends LitElement {
       </header>
       <div>
         ${fetchNpmPackage(this.name,
-          (pkg) => html`
-            <h3>${pkg.description}</h3>
-            <h4>dist-tags:</h4>
-            <ul>
-              ${Array.from(Object.entries(pkg['dist-tags'])).map(
-                ([tag, version]) => html`<li><pre>${tag}: ${version}</pre></li>`)}
-            </ul>
-          `,
-          () => 'Loading...',
-          () => 'Enter a Package Name',
-          (e) => `Error ${e.message}`)}
+          {
+            success: (pkg) => html`
+              <h3>${pkg.description}</h3>
+              <h4>dist-tags:</h4>
+              <ul>
+                ${Array.from(Object.entries(pkg['dist-tags'])).map(
+                  ([tag, version]) => html`<li><pre>${tag}: ${version}</pre></li>`)}
+              </ul>
+            `,
+            pending: () => 'Loading...',
+            initial: () => 'Enter a Package Name',
+            failure: (e) => `Error ${e.message}`
+          })
+        }
       </div>
     `;
   }

--- a/packages/await-io/src/run-async.ts
+++ b/packages/await-io/src/run-async.ts
@@ -25,10 +25,12 @@ const runs = new WeakMap<Part, AsyncRunState>();
 
 export type RunAsyncDirective<K> = (
     key: K,
-    success: (result: any) => any,
-    pending?: () => any,
-    initial?: () => any,
-    failure?: (e: Error) => any,
+    handlers: {
+      success: (result: any) => any,
+      pending?: () => any,
+      initial?: () => any,
+      failure?: (e: Error) => any,
+    }
   ) => void;
 
 /**
@@ -46,10 +48,12 @@ export type RunAsyncDirective<K> = (
 export const runAsync = <K>(
   f: (key: K, options: {signal?: AbortSignal}) => Promise<unknown>): RunAsyncDirective<K> => (
   key: K,
-  success: (result: any) => any,
-  pending?: () => any,
-  initial?: () => any,
-  failure?: (e: Error) => any,
+  {
+    success,
+    pending,
+    initial,
+    failure,
+  }
 ) => directive((part: NodePart) => {
   
   const currentRunState = runs.get(part);

--- a/packages/await-io/src/search-demo.ts
+++ b/packages/await-io/src/search-demo.ts
@@ -71,17 +71,18 @@ export class SearchDemo extends PendingContainer(LitElement) {
             @input=${this._onInput}>
         </div>
       </header>
-      ${searchPackages(this.query,
-        (data) => html`
+      ${searchPackages(this.query, {
+        success: (data) => html`
         <div id="results">
           ${repeat(data.objects.slice(10),
               (i: any) => i.package.name,
               (i: any) => html`<search-item .package=${i.package}></search-item>`)}
         </div>`,
-        // () => html`<md-spinner active></md-spinner>`,
-        () => html`<p>Loading...</p>`,
-        () => html`<p>Enter a Search Term</p>`,
-        (e) => html`<p>${e.message}</p>`)}
+        // pending: () => html`<md-spinner active></md-spinner>`,
+        pending: () => html`<p>Loading...</p>`,
+        initial: () => html`<p>Enter a Search Term</p>`,
+        failure: (e) => html`<p>${e.message}</p>`,
+      })}
     `;
   }
 
@@ -155,15 +156,18 @@ export class SearchItem extends LazyLitElement {
       <div>
       <p>${this.package.description}</p>
         <div>Version: ${this.package.version}</div>
-        ${fetchNpmPackage(this.package.name,
-          (pkg) => html`
-            <h4>dist-tags:</h4>
-            <ul>
-              ${Array.from(Object.entries(pkg['dist-tags'])).map(
-                ([tag, version]) => html`<li><pre>${tag}: ${version}</pre></li>`)}
-            </ul>
-          `/*,
-        () => html`<md-spinner active></md-spinner>`*/)}
+          ${fetchNpmPackage(this.package.name,
+            {
+              success: (pkg) => html`
+                <h4>dist-tags:</h4>
+                <ul>
+                  ${Array.from(Object.entries(pkg['dist-tags'])).map(
+                    ([tag, version]) => html`<li><pre>${tag}: ${version}</pre></li>`
+                    )}
+                </ul>
+              `,
+              // pending: () => html`<md-spinner active></md-spinner>`
+            })}
       </div>
     `;
   }


### PR DESCRIPTION
This changes the `runAsync` function to accept a map/object instead of args. This makes the handlers order independent.